### PR TITLE
afs.console: fix on Linux - Cannot process request because the process has exited

### DIFF
--- a/AssFontSubset.Core/src/PyFontTools.cs
+++ b/AssFontSubset.Core/src/PyFontTools.cs
@@ -203,7 +203,6 @@ public class PyFontTools(string pyftsubset, string ttx, ILogger? logger) : Subse
             process.WaitForExit();
             var exitCode = process.ExitCode;
 
-            var processTime = process.TotalProcessorTime;
             sw.Stop();
 
             if (exitCode != 0)


### PR DESCRIPTION
On Linux, accessing TotalProcessorTime gets you error.

```
2025-02-11T18:37:47-08:00|DBG|Executing...
2025-02-11T18:37:47-08:00|ERR|Cannot process request because the process (88010) has exited.
```

Since it's not being used anywhere, delete the call to unblock running under Linux.